### PR TITLE
Added basic LockScreen support for unlocked devices.

### DIFF
--- a/AppPage.xm
+++ b/AppPage.xm
@@ -104,12 +104,18 @@
 
 - (BOOL)isDeviceUnlocked {
   return ![(SpringBoard*)[%c(SpringBoard) sharedApplication] isLocked];
+  BOOL isDeviceUnlocked = NO;
+if (isDeviceUnlocked) { // Should ignore lockstate.
+    [self reloadForUnlock];
+} else {
+    [self reloadForUnlock];
+}
 }
 
 - (void)setInfoLabelText {
   self.infoLabel.text = [self isDeviceUnlocked] ?
     [NSString stringWithFormat:@"%@ is running in the foreground", self.app.displayName] :
-    [NSString stringWithFormat:@"Unlock to use %@", self.app.displayName];
+    [NSString stringWithFormat:@"%@ isn't working. Are you unlocked?", self.app.displayName];
 }
 
 - (void)reloadForUnlock {
@@ -204,9 +210,9 @@
 
       [UIView animateWithDuration:0.25 animations:^{
         self.appIconImageView.alpha = 1.0;
-        if ([self isDeviceUnlocked]) {
+        if(true) { // Just need a boolean to fill this..
           self.hostView.alpha = 1.0;
-          [self stopSendingTouchesToApp];
+          [self stopSendingTouchesToApp]; // Should be good! App acess enabled on LockScreen.
           [self performSelector:@selector(startSendingTouchesToApp) withObject:self afterDelay:0.6];
         }
       }];

--- a/SelectionPage.xm
+++ b/SelectionPage.xm
@@ -435,7 +435,7 @@
 
   self.lockedLabel = [[CCUIControlCenterLabel alloc] initWithFrame:CGRectMake(0,0,200,10)];
   self.lockedLabel.translatesAutoresizingMaskIntoConstraints = false;
-  self.lockedLabel.text = @"Unlock to use App Center";
+  self.lockedLabel.text = @"App Center is broken on the LockScreen.";
   self.lockedLabel.textAlignment = NSTextAlignmentCenter;
   self.lockedLabel.font = [UIFont systemFontOfSize:[ACManualLayout appDisplayNameFontSize]*3/2];
   [self.lockedLabel setStyle:(unsigned long long) 0];//dark translucent text
@@ -496,10 +496,10 @@
   if (!reloadingControlCenter) {
     [self.gridViewController.collectionView reloadData];
     if ([(SpringBoard*)[%c(SpringBoard) sharedApplication] isLocked]) {
-      self.gridViewController.view.hidden = true;
-      self.view.searchButton.hidden = true;
+      self.gridViewController.view.hidden = false; // Should allow for app selection.
+      self.view.searchButton.hidden = false; // Enable search.
       [self.view addSubview:self.lockedLabel];
-      self.lockedLabel.alpha = 1.0;
+      self.lockedLabel.alpha = 0.0;
       [self.view addConstraint:[NSLayoutConstraint constraintWithItem:self.gridViewController.view attribute:NSLayoutAttributeCenterY relatedBy:NSLayoutRelationEqual toItem:self.lockedLabel attribute:NSLayoutAttributeCenterY multiplier:1.0 constant:0]];
       [self.view addConstraint:[NSLayoutConstraint constraintWithItem:self.gridViewController.view attribute:NSLayoutAttributeCenterX relatedBy:NSLayoutRelationEqual toItem:self.lockedLabel attribute:NSLayoutAttributeCenterX multiplier:1.0 constant:0]];
     }

--- a/Tweak.xm
+++ b/Tweak.xm
@@ -248,10 +248,14 @@ BOOL isNotFirstRun = false;
   notify_register_dispatch("com.apple.springboard.lockstate", &notify_token,dispatch_get_main_queue(), ^(int token) {
     uint64_t state = UINT64_MAX;
     notify_get_state(token, &state);
-    if (state == 0) { // unlocked
-      [self appcenter_reloadForUnlock];
-    }
-  });
+    if (state == 0) { // Should ignore lockstate.
+            [self appcenter_reloadForUnlock];
+
+        } else {
+            [self appcenter_reloadForUnlock];
+        }
+
+    });
 }
 
 %new


### PR DESCRIPTION
This adds support for using App Center and running applications on the LockScreen while the device is in an unlocked state. It's kinda buggy right now but it works well enough.

I mainly tried this because I figured it might work with Xen, but so far that hasn't been the case (Xen doesn't handle CC changes on the LS very well so it crashes into Safe Mode.)